### PR TITLE
Add aoc-linux-fixes tool, modified multiprocessing for efficiency 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ output.csv
 **/cscope.file
 **/errors.json
 **/cscope
+profile_*

--- a/README.md
+++ b/README.md
@@ -38,3 +38,13 @@ aoc-cocci dir-with-c-files --patch reversed_subscript --output-dir output
 
 This command specifies that only the reversed subscript patch should be applied and the results should be saved to 
 the output directory.
+
+To run the linux fixes tool use the command `aoc-linux-fixes`. This tool is used to examine bug fix commits to the linux kernel.
+
+```bash
+aoc-linux-fixes dir-with-linux-repo --output-dir output_dir --history_length "1 year" --cpus 4
+```
+
+This command specifies to run atoms patches on linux kernel commits going back 1 year from now using 4 worker processes.
+If history length is not specified, all commits going back to the introduction of specific commit messages for bug fixes.
+If cpus is set to 0, it will use the system's cpu count, default is 4.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     entry_points={
         "console_scripts": [
             "aoc-cocci = src.tools.aoc_cocci:atom_finder",
-            "aoc-linux-fixes = src.analysis.scripts.extract_fixes:extract_linux_fixes"
+            "aoc-linux-fixes = src.tools.aoc_linux_fixes:extract_linux_fixes"
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="The Atoms of Confusion Project",
     packages=["src"],
     include_package_data=True,
-    install_requires=["click", "pytest"],
+    install_requires=["click", "pytest","pygit2","clang==14"],
     extras_require={
         "selenium": [
             "selenium>=4.0.0",
@@ -20,6 +20,7 @@ setup(
     entry_points={
         "console_scripts": [
             "aoc-cocci = src.tools.aoc_cocci:atom_finder",
+            "aoc-linux-fixes = src.analysis.scripts.extract_fixes:extract_linux_fixes"
         ],
     },
 )

--- a/src/analysis/scripts/extract_fixes.py
+++ b/src/analysis/scripts/extract_fixes.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-import click
+import cProfile
 import csv
 import json
 import multiprocessing
@@ -23,7 +23,7 @@ COMMITS_FILE_PATH = Path("commits.json")  # Path to a JSON file containing commi
 RESULTS_DIR = Path("./results")
 LAST_PROCESSED_DIR = Path("./last_processed")
 ERRORS_FILE_DIR = Path("./extract")
-NUMBER_OF_PROCESSES = 5
+NUMBER_OF_PROCESSES = 1
 
 
 def find_removed_atoms(repo, commit):
@@ -92,7 +92,7 @@ def iterate_commits_and_extract_removed_code(repo_path, stop_commit, commits_fil
     stop_iteration = False
     for commit in repo.walk(head, pygit2.GIT_SORT_TIME):
         commit_message = commit.message.strip()
-        print(commit.id)
+        #print(commit.id)
 
         # Filter by cutoff timestamp if set
         if cutoff_timestamp is not None and commit.commit_time < cutoff_timestamp:
@@ -190,13 +190,7 @@ def combine_results(results_folder):
                             writer.writerow(row)
 
 
-#if __name__ == "__main__":
-@click.command()
-@click.argument("linux_dir",type=Path)
-@click.option("-o", "--output-dir", type=Path, default="./output")
-@click.option("-t","--history_length",type=str, default=None)
-
-def extract_linux_fixes(linux_dir,output_dir:Path,history_length):
+def extract_linux_fixes(linux_dir = REPO_PATH,output_dir = Path("./output"),history_length = None):
     stop_commit = "c511851de162e8ec03d62e7d7feecbdf590d881d" # this is the commit when the fix: convention was introduced
     output_dir.mkdir(exist_ok=True)
     commits_file_path = output_dir / "commits.json"
@@ -216,12 +210,12 @@ def extract_linux_fixes(linux_dir,output_dir:Path,history_length):
     commits = json.loads(commits_file_path.read_text())
     # commits = ["e589f9b7078e1c0191613cd736f598e81d2390de"]
 
-"""    if len(commits) == 1 or NUMBER_OF_PROCESSES == 1:
+    if len(commits) == 1 or NUMBER_OF_PROCESSES == 1:
         get_removed_lines(linux_dir, commits, results_dir / "atoms.csv", last_processed / "last_processed.json", errors_dir / "errors.json")
     else:
         execute(linux_dir, commits, NUMBER_OF_PROCESSES, results_dir, last_processed, errors_dir)
 
-    combine_results(results_dir)"""
+    combine_results(results_dir)
 
 if __name__ == "__main__":
-    extract_linux_fixes()
+    cProfile.run('extract_linux_fixes(Path("../projects/linux/"), Path("./output"), "one month")',"profile_linux_fixes" )

--- a/src/analysis/scripts/extract_fixes.py
+++ b/src/analysis/scripts/extract_fixes.py
@@ -196,7 +196,7 @@ def _get_removed_lines_worker(repo_path, commit_queue, output, processed_path, e
             continue
         try:
             commit = repo.get(commit_sha)
-            atoms = find_removed_atoms(repo, commit, pool)
+            atoms = find_removed_atoms(repo, commit)
             count += 1
             if atoms:
                 append_rows_to_csv(output, atoms)

--- a/src/analysis/scripts/extract_fixes.py
+++ b/src/analysis/scripts/extract_fixes.py
@@ -1,11 +1,14 @@
 from collections import defaultdict
+import click
 import csv
 import json
 import multiprocessing
 import re
 import tempfile
 import pygit2
+import time
 from pathlib import Path
+from timelength import TimeLength
 from src import ROOT_DIR
 from src.analysis.utils.parsing import run_coccinelle_for_file_at_commit
 from src.analysis.utils.git import get_diff
@@ -15,11 +18,11 @@ from src.log import logger
 
 
 PATCHES_TO_SKIP = [CocciPatch.OMITTED_CURLY_BRACES]
-REPO_PATH = (ROOT_DIR.parent / "atoms/projects/linux").absolute()  # Path to the Linux kernel Git repository
-COMMITS_FILE_PATH = Path("../commits.json")  # Path to a JSON file containing commit hashes
-RESULTS_DIR = Path("../results")
-LAST_PROCESSED_DIR = Path("../last_processed")
-ERRORS_FILE_DIR = RESULTS_DIR/ "extract"
+REPO_PATH = (ROOT_DIR.parent / "projects/linux").absolute()  # Path to the Linux kernel Git repository
+COMMITS_FILE_PATH = Path("commits.json")  # Path to a JSON file containing commit hashes
+RESULTS_DIR = Path("./results")
+LAST_PROCESSED_DIR = Path("./last_processed")
+ERRORS_FILE_DIR = Path("./extract")
 NUMBER_OF_PROCESSES = 5
 
 
@@ -27,7 +30,7 @@ def find_removed_atoms(repo, commit):
     """
     Get removed lines (lines removed in a commit) by comparing the commit to its parent.
     """
-    logger.info(f"Current commit: {commit.hex}")
+    logger.info(f"Current commit: {commit.id}")
     atoms = []
 
     _, removed_lines = get_diff(repo, commit)
@@ -54,13 +57,13 @@ def find_removed_atoms(repo, commit):
 
             for row in atoms:
                 atom, path, start_line, start_col, end_line, end_col, code = row
-                output_row = [atom, file_name, commit.hex, start_line, start_col, code]
+                output_row = [atom, file_name, str(commit.id), start_line, start_col, code]
                 output.append(output_row)
 
     return output
 
 
-def iterate_commits_and_extract_removed_code(repo_path, stop_commit):
+def iterate_commits_and_extract_removed_code(repo_path, stop_commit, commits_file_path ,history_length = None):
     """
     Iterate through commits, check commit message, and retrieve removed code if condition is met.
     Stop iteration when the stop_commit is reached.
@@ -76,11 +79,24 @@ def iterate_commits_and_extract_removed_code(repo_path, stop_commit):
     # Regular expression to match 'Fixes: <SHA>'
     fixes_pattern = re.compile(r"Fixes:\s+([0-9a-fA-F]{6,12})", re.IGNORECASE)
 
+    # Calculate cutoff timestamp if history_length is provided
+    cutoff_timestamp = None
+    if history_length is not None:
+        tl = TimeLength(history_length)
+        now = int(time.time())
+        cutoff_timestamp = now - int(tl.to_minutes()*60)
+
+
     commit_fixes = []
 
     stop_iteration = False
     for commit in repo.walk(head, pygit2.GIT_SORT_TIME):
         commit_message = commit.message.strip()
+        print(commit.id)
+
+        # Filter by cutoff timestamp if set
+        if cutoff_timestamp is not None and commit.commit_time < cutoff_timestamp:
+            break
 
         # make sure the last pair is added
         if stop_iteration:
@@ -88,13 +104,13 @@ def iterate_commits_and_extract_removed_code(repo_path, stop_commit):
 
         # Check the condition using the regex
         if fixes_pattern.search(commit_message):
-            commit_fixes.append(commit.hex)
+            commit_fixes.append(str(commit.id))
 
         # Stop when the specific commit is reached
-        if str(commit.hex) == stop_commit:
+        if str(commit.id) == stop_commit:
             stop_iteration = True
 
-    Path(COMMITS_FILE_PATH).write_text(json.dumps(commit_fixes))
+    commits_file_path.write_text(json.dumps(commit_fixes))
 
 
 def load_processed_data(processed_path):
@@ -130,7 +146,7 @@ def get_removed_lines(repo_path, commits, output, processed_path, errors_path):
             logger.error(e)
             append_to_json(errors_path, {"commit_sha": commit_sha, "error": str(e)})
             continue
-        processed.update({"count": count, "count_w_atoms": count_w_atoms, "last_commit": commit.hex})
+        processed.update({"count": count, "count_w_atoms": count_w_atoms, "last_commit": str(commit.id)})
         processed_path.write_text(json.dumps(processed))
 
 
@@ -157,8 +173,7 @@ def chunkify(lst, n):
     return [lst[i * k + min(i, m) : (i + 1) * k + min(i + 1, m)] for i in range(n)]
 
 
-def combine_results():
-    results_folder = RESULTS_DIR
+def combine_results(results_folder):
 
     combined_file_path = results_folder / "atoms.csv"
 
@@ -175,23 +190,38 @@ def combine_results():
                             writer.writerow(row)
 
 
-if __name__ == "__main__":
+#if __name__ == "__main__":
+@click.command()
+@click.argument("linux_dir",type=Path)
+@click.option("-o", "--output-dir", type=Path, default="./output")
+@click.option("-t","--history_length",type=str, default=None)
 
+def extract_linux_fixes(linux_dir,output_dir:Path,history_length):
     stop_commit = "c511851de162e8ec03d62e7d7feecbdf590d881d" # this is the commit when the fix: convention was introduced
-    commits = safely_load_json(COMMITS_FILE_PATH)
+    output_dir.mkdir(exist_ok=True)
+    commits_file_path = output_dir / "commits.json"
+
+
+    commits = safely_load_json(commits_file_path)
     if not commits or commits[-1] != stop_commit:
-        iterate_commits_and_extract_removed_code(REPO_PATH, stop_commit)
+        iterate_commits_and_extract_removed_code(linux_dir, stop_commit, commits_file_path, history_length)
 
-    LAST_PROCESSED_DIR.mkdir(exist_ok=True)
-    RESULTS_DIR.mkdir(exist_ok=True)
-    ERRORS_FILE_DIR.parent.mkdir(exist_ok=True)
+    last_processed = output_dir / LAST_PROCESSED_DIR
+    last_processed.mkdir(exist_ok=True)
+    results_dir = output_dir/RESULTS_DIR
+    results_dir.mkdir(exist_ok=True)
+    errors_dir = results_dir / ERRORS_FILE_DIR
+    errors_dir.mkdir(exist_ok=True)
 
-    commits = json.loads(Path(COMMITS_FILE_PATH).read_text())
+    commits = json.loads(commits_file_path.read_text())
     # commits = ["e589f9b7078e1c0191613cd736f598e81d2390de"]
 
-    if len(commits) == 1 or NUMBER_OF_PROCESSES == 1:
-        get_removed_lines(REPO_PATH, commits, RESULTS_DIR / "atoms.csv", LAST_PROCESSED_DIR / "last_processed.json", ERRORS_FILE_DIR / "errors.json")
+"""    if len(commits) == 1 or NUMBER_OF_PROCESSES == 1:
+        get_removed_lines(linux_dir, commits, results_dir / "atoms.csv", last_processed / "last_processed.json", errors_dir / "errors.json")
     else:
-        execute(REPO_PATH, commits, NUMBER_OF_PROCESSES, RESULTS_DIR, LAST_PROCESSED_DIR, ERRORS_FILE_DIR)
+        execute(linux_dir, commits, NUMBER_OF_PROCESSES, results_dir, last_processed, errors_dir)
 
-    combine_results()
+    combine_results(results_dir)"""
+
+if __name__ == "__main__":
+    extract_linux_fixes()

--- a/src/analysis/scripts/extract_fixes.py
+++ b/src/analysis/scripts/extract_fixes.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-import cProfile
 import csv
 import json
 import multiprocessing
@@ -16,15 +15,7 @@ from src.analysis.utils.utils import append_rows_to_csv, append_to_json, safely_
 from src.run_cocci import CocciPatch
 from src.log import logger
 
-
 PATCHES_TO_SKIP = [CocciPatch.OMITTED_CURLY_BRACES]
-REPO_PATH = (ROOT_DIR.parent / "projects/linux").absolute()  # Path to the Linux kernel Git repository
-COMMITS_FILE_PATH = Path("commits.json")  # Path to a JSON file containing commit hashes
-RESULTS_DIR = Path("./results")
-LAST_PROCESSED_DIR = Path("./last_processed")
-ERRORS_FILE_DIR = Path("./extract")
-NUMBER_OF_PROCESSES = 1
-
 
 def find_removed_atoms(repo, commit):
     """
@@ -159,7 +150,7 @@ def execute(repo_path, commits, number_of_processes, results_dir, last_procesed_
     """
     Main function to spawn the processes.
     """
-    if number_of_processes == 0:
+    if not number_of_processes:
         number_of_processes = multiprocessing.cpu_count()
     # Create a pool of worker processes
     chunks = chunkify(commits, number_of_processes)
@@ -227,7 +218,7 @@ def execute_queue(repo_path, commits, number_of_processes, results_dir, last_pro
         number_of_processes (int): number of worker processes to use
         *_dir (path): output directories 
     '''
-    if number_of_processes == 0:
+    if not number_of_processes:
         number_of_processes = multiprocessing.cpu_count()
 
     manager = multiprocessing.Manager()

--- a/src/analysis/scripts/extract_fixes.py
+++ b/src/analysis/scripts/extract_fixes.py
@@ -160,7 +160,7 @@ def execute(repo_path, commits, number_of_processes, results_dir, last_procesed_
     Main function to spawn the processes.
     """
     if number_of_processes == 0:
-        number_of_processes = multiprocessing.cpu_count() - 2
+        number_of_processes = multiprocessing.cpu_count()
     # Create a pool of worker processes
     chunks = chunkify(commits, number_of_processes)
     with multiprocessing.Pool(processes=number_of_processes) as pool:
@@ -228,7 +228,7 @@ def execute_queue(repo_path, commits, number_of_processes, results_dir, last_pro
         *_dir (path): output directories 
     '''
     if number_of_processes == 0:
-        number_of_processes = multiprocessing.cpu_count() - 2
+        number_of_processes = multiprocessing.cpu_count()
 
     manager = multiprocessing.Manager()
     commit_queue = manager.Queue()

--- a/src/analysis/scripts/extract_fixes.py
+++ b/src/analysis/scripts/extract_fixes.py
@@ -154,6 +154,8 @@ def execute(repo_path, commits, number_of_processes, results_dir, last_procesed_
     """
     Main function to spawn the processes.
     """
+    if number_of_processes == 0:
+        number_of_processes = multiprocessing.cpu_count()
     # Create a pool of worker processes
     chunks = chunkify(commits, number_of_processes)
     with multiprocessing.Pool(processes=number_of_processes) as pool:
@@ -190,7 +192,9 @@ def combine_results(results_folder):
                             writer.writerow(row)
 
 
-def extract_linux_fixes(linux_dir = REPO_PATH,output_dir = Path("./output"),history_length = None):
+#Similar to the aoc_linux_fixes tool, this version is used to run the profiler
+def extract_linux_fixes(linux_dir = REPO_PATH,output_dir = Path("./output"),history_length = None,num_cpu = NUMBER_OF_PROCESSES):
+
     stop_commit = "c511851de162e8ec03d62e7d7feecbdf590d881d" # this is the commit when the fix: convention was introduced
     output_dir.mkdir(exist_ok=True)
     commits_file_path = output_dir / "commits.json"
@@ -210,10 +214,10 @@ def extract_linux_fixes(linux_dir = REPO_PATH,output_dir = Path("./output"),hist
     commits = json.loads(commits_file_path.read_text())
     # commits = ["e589f9b7078e1c0191613cd736f598e81d2390de"]
 
-    if len(commits) == 1 or NUMBER_OF_PROCESSES == 1:
+    if len(commits) == 1 or num_cpu == 1:
         get_removed_lines(linux_dir, commits, results_dir / "atoms.csv", last_processed / "last_processed.json", errors_dir / "errors.json")
     else:
-        execute(linux_dir, commits, NUMBER_OF_PROCESSES, results_dir, last_processed, errors_dir)
+        execute(linux_dir, commits, num_cpu, results_dir, last_processed, errors_dir)
 
     combine_results(results_dir)
 

--- a/src/analysis/scripts/extract_fixes.py
+++ b/src/analysis/scripts/extract_fixes.py
@@ -155,7 +155,7 @@ def execute(repo_path, commits, number_of_processes, results_dir, last_procesed_
     Main function to spawn the processes.
     """
     if number_of_processes == 0:
-        number_of_processes = multiprocessing.cpu_count()
+        number_of_processes = multiprocessing.cpu_count() - 2
     # Create a pool of worker processes
     chunks = chunkify(commits, number_of_processes)
     with multiprocessing.Pool(processes=number_of_processes) as pool:
@@ -174,6 +174,71 @@ def chunkify(lst, n):
     k, m = divmod(len(lst), n)
     return [lst[i * k + min(i, m) : (i + 1) * k + min(i + 1, m)] for i in range(n)]
 
+
+def _get_removed_lines_worker(repo_path, commit_queue, output, processed_path, errors_path, pool=None):
+    """Worker function that pulls commits from the shared queue."""
+    repo = pygit2.Repository(str(repo_path))
+    processed = load_processed_data(processed_path)
+    count, count_w_atoms = processed["count"], processed["count_w_atoms"]
+    first_commit = processed["last_commit"]
+    found_first_commit = first_commit is None
+
+    while True:
+        try:
+            commit_sha = commit_queue.get_nowait()
+        except Exception:
+            break  # Queue is empty
+
+        if first_commit and not found_first_commit:
+            found_first_commit = commit_sha == first_commit
+            continue
+        if not found_first_commit:
+            continue
+        try:
+            commit = repo.get(commit_sha)
+            atoms = find_removed_atoms(repo, commit, pool)
+            count += 1
+            if atoms:
+                append_rows_to_csv(output, atoms)
+                count_w_atoms += 1
+            logger.info(f"Processed {count} commits, {count_w_atoms} with atoms.")
+        except Exception as e:
+            logger.error(e)
+            append_to_json(errors_path, {"commit_sha": commit_sha, "error": str(e)})
+            continue
+        processed.update({"count": count, "count_w_atoms": count_w_atoms, "last_commit": str(commit.id)})
+        processed_path.write_text(json.dumps(processed))
+
+
+def execute_queue(repo_path, commits, number_of_processes, results_dir, last_procesed_dir, errors_dir):
+    """
+    Main function to spawn the processes using a shared queue.
+    """
+    if number_of_processes == 0:
+        number_of_processes = multiprocessing.cpu_count() - 2
+
+    manager = multiprocessing.Manager()
+    commit_queue = manager.Queue()
+    for commit in commits:
+        commit_queue.put(commit)
+
+    processes = []
+    for i in range(number_of_processes):
+        p = multiprocessing.Process(
+            target=_get_removed_lines_worker,
+            args=(
+                repo_path,
+                commit_queue,
+                results_dir / f"atoms{i+1}.csv",
+                last_procesed_dir / f"last_processed{i+1}.json",
+                errors_dir / f"errors{i+1}.json",
+            ),
+        )
+        p.start()
+        processes.append(p)
+
+    for p in processes:
+        p.join()
 
 def combine_results(results_folder):
 
@@ -217,9 +282,10 @@ def extract_linux_fixes(linux_dir = REPO_PATH,output_dir = Path("./output"),hist
     if len(commits) == 1 or num_cpu == 1:
         get_removed_lines(linux_dir, commits, results_dir / "atoms.csv", last_processed / "last_processed.json", errors_dir / "errors.json")
     else:
-        execute(linux_dir, commits, num_cpu, results_dir, last_processed, errors_dir)
-
+        #execute(linux_dir, commits, num_cpu, results_dir, last_processed, errors_dir)
+        execute_queue(linux_dir, commits, num_cpu, results_dir, last_processed, errors_dir)
+    
     combine_results(results_dir)
 
 if __name__ == "__main__":
-    cProfile.run('extract_linux_fixes(Path("../projects/linux/"), Path("./output"), "one month")',"profile_linux_fixes" )
+    cProfile.run('extract_linux_fixes(Path("../projects/linux/"), Path("./output"), "one month",0)',"profile_linux_fixes" )

--- a/src/run_cocci.py
+++ b/src/run_cocci.py
@@ -152,7 +152,16 @@ def postprocess_and_generate_output(file_path: Path,  patch: CocciPatch, remove_
     return filtered_data
 
 
-def run_patches_and_generate_output(input_path: Path, output_path: Optional[Path] = None, temp_dir: Optional[Path] = None, split_output = True, patch: Optional[CocciPatch] = None,  patches_to_skip: Optional[list] = None, remove_end_line_and_col: Optional[bool]=True, cocci_dir:Optional[Path]=COCCI_DIR):
+def run_patches_and_generate_output(
+        input_path: Path, 
+        output_path: Optional[Path] = None, 
+        temp_dir: Optional[Path] = None, 
+        split_output = True, 
+        patch: Optional[CocciPatch] = None,  
+        patches_to_skip: Optional[list] = None, 
+        remove_end_line_and_col: Optional[bool]=True, 
+        cocci_dir:Optional[Path]=COCCI_DIR
+):
     logging.debug("Running patches")
     patches_to_skip = patches_to_skip or []
     if patch is None:

--- a/src/tools/aoc_cocci.py
+++ b/src/tools/aoc_cocci.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from io import StringIO
 
 from src.option_select import select
-from src.run_cocci import run_cocci, COCCI_DIR, find_atoms, CocciPatch, run_patches_and_generate_output
+from src.run_cocci import run_cocci, COCCI_DIR, CocciPatch, run_patches_and_generate_output#, find_atoms
 from src.utils import append_to_csv
 from src.log import logging
 

--- a/src/tools/aoc_linux_fixes.py
+++ b/src/tools/aoc_linux_fixes.py
@@ -31,7 +31,7 @@ This tool takes up to 4 arguments:
 @click.argument("linux_dir",type=Path)
 @click.option("-o", "--output-dir", type=Path, default="./output")
 @click.option("-t","--history_length",type=str, default=None,help="Length of commit history to analyze")
-@click.option("-p","--cpus",type=int,default=1,help="number of cpus to use for multiprocessing. Enter 0 to select all")
+@click.option("-p","--cpus",type=int,default=None,help="number of cpus to use for multiprocessing. Defaults to cpu_count")
 
 def extract_linux_fixes(linux_dir = REPO_PATH,output_dir = Path("./output"),history_length = None, cpus = NUMBER_OF_PROCESSES):
 

--- a/src/tools/aoc_linux_fixes.py
+++ b/src/tools/aoc_linux_fixes.py
@@ -3,7 +3,7 @@ import json
 #import cProfile
 
 from pathlib import Path
-from src.analysis.scripts.extract_fixes import iterate_commits_and_extract_removed_code, get_removed_lines,execute, combine_results
+from src.analysis.scripts.extract_fixes import iterate_commits_and_extract_removed_code, get_removed_lines,execute, combine_results,execute_queue
 from src.analysis.utils.utils import safely_load_json
 from src import ROOT_DIR
 
@@ -45,7 +45,8 @@ def extract_linux_fixes(linux_dir = REPO_PATH,output_dir = Path("./output"),hist
     if len(commits) == 1 or cpus == 1:
         get_removed_lines(linux_dir, commits, results_dir / "atoms.csv", last_processed / "last_processed.json", errors_dir / "errors.json")
     else:
-        execute(linux_dir, commits, cpus, results_dir, last_processed, errors_dir)
+        #execute(linux_dir, commits, cpus, results_dir, last_processed, errors_dir)
+        execute_queue(linux_dir, commits, cpus, results_dir, last_processed, errors_dir)
 
     combine_results(results_dir)
 

--- a/src/tools/aoc_linux_fixes.py
+++ b/src/tools/aoc_linux_fixes.py
@@ -15,6 +15,17 @@ ERRORS_FILE_DIR = Path("./extract")
 
 NUMBER_OF_PROCESSES = 4
 
+'''
+aoc-linux-fixes is a tool for examining bug fix commits to the linux kernel
+It runs coccinelle patches on the changes made by the bug fix to see if the removed/modified code 
+contained any atoms, or was infulence by the presence of atoms.
+
+This tool takes up to 4 arguments:
+- The directory containing a clone of the linux kernel
+- A directory path for output
+- A length of time from now for which to process commits
+- The number of worker processes to spawn
+'''
 
 @click.command()
 @click.argument("linux_dir",type=Path)
@@ -22,7 +33,7 @@ NUMBER_OF_PROCESSES = 4
 @click.option("-t","--history_length",type=str, default=None,help="Length of commit history to analyze")
 @click.option("-p","--cpus",type=int,default=1,help="number of cpus to use for multiprocessing. Enter 0 to select all")
 
-def extract_linux_fixes(linux_dir = REPO_PATH,output_dir = Path("./output"),history_length = None, cpus = 1):
+def extract_linux_fixes(linux_dir = REPO_PATH,output_dir = Path("./output"),history_length = None, cpus = NUMBER_OF_PROCESSES):
 
     stop_commit = "c511851de162e8ec03d62e7d7feecbdf590d881d" # this is the commit when the fix: convention was introduced
     output_dir.mkdir(exist_ok=True)
@@ -52,3 +63,4 @@ def extract_linux_fixes(linux_dir = REPO_PATH,output_dir = Path("./output"),hist
 
 if __name__ == "__main__":
     extract_linux_fixes(Path("../projects/linux/"), Path("./output"), "one week", NUMBER_OF_PROCESSES)
+    #cProfile.run('extract_linux_fixes(Path("../projects/linux/"), Path("./output"), "one month",0)',"profile_linux_fixes" )

--- a/src/tools/aoc_linux_fixes.py
+++ b/src/tools/aoc_linux_fixes.py
@@ -20,8 +20,10 @@ NUMBER_OF_PROCESSES = 4
 @click.argument("linux_dir",type=Path)
 @click.option("-o", "--output-dir", type=Path, default="./output")
 @click.option("-t","--history_length",type=str, default=None,help="Length of commit history to analyze")
+@click.option("-p","--cpus",type=int,default=1,help="number of cpus to use for multiprocessing. Enter 0 to select all")
 
-def extract_linux_fixes(linux_dir = REPO_PATH,output_dir = Path("./output"),history_length = None):
+def extract_linux_fixes(linux_dir = REPO_PATH,output_dir = Path("./output"),history_length = None, cpus = 1):
+
     stop_commit = "c511851de162e8ec03d62e7d7feecbdf590d881d" # this is the commit when the fix: convention was introduced
     output_dir.mkdir(exist_ok=True)
     commits_file_path = output_dir / "commits.json"
@@ -40,12 +42,12 @@ def extract_linux_fixes(linux_dir = REPO_PATH,output_dir = Path("./output"),hist
     commits = json.loads(commits_file_path.read_text())
     # commits = ["e589f9b7078e1c0191613cd736f598e81d2390de"]
 
-    if len(commits) == 1 or NUMBER_OF_PROCESSES == 1:
+    if len(commits) == 1 or cpus == 1:
         get_removed_lines(linux_dir, commits, results_dir / "atoms.csv", last_processed / "last_processed.json", errors_dir / "errors.json")
     else:
-        execute(linux_dir, commits, NUMBER_OF_PROCESSES, results_dir, last_processed, errors_dir)
+        execute(linux_dir, commits, cpus, results_dir, last_processed, errors_dir)
 
     combine_results(results_dir)
 
 if __name__ == "__main__":
-    extract_linux_fixes(Path("../projects/linux/"), Path("./output"), "one week")
+    extract_linux_fixes(Path("../projects/linux/"), Path("./output"), "one week", NUMBER_OF_PROCESSES)

--- a/src/tools/aoc_linux_fixes.py
+++ b/src/tools/aoc_linux_fixes.py
@@ -1,0 +1,51 @@
+import click
+import json
+#import cProfile
+
+from pathlib import Path
+from src.analysis.scripts.extract_fixes import iterate_commits_and_extract_removed_code, get_removed_lines,execute, combine_results
+from src.analysis.utils.utils import safely_load_json
+from src import ROOT_DIR
+
+REPO_PATH = (ROOT_DIR.parent / "projects/linux").absolute()  # Path to the Linux kernel Git repository
+COMMITS_FILE_PATH = Path("commits.json")  # Path to a JSON file containing commit hashes
+RESULTS_DIR = Path("./results")
+LAST_PROCESSED_DIR = Path("./last_processed")
+ERRORS_FILE_DIR = Path("./extract")
+
+NUMBER_OF_PROCESSES = 4
+
+
+@click.command()
+@click.argument("linux_dir",type=Path)
+@click.option("-o", "--output-dir", type=Path, default="./output")
+@click.option("-t","--history_length",type=str, default=None,help="Length of commit history to analyze")
+
+def extract_linux_fixes(linux_dir = REPO_PATH,output_dir = Path("./output"),history_length = None):
+    stop_commit = "c511851de162e8ec03d62e7d7feecbdf590d881d" # this is the commit when the fix: convention was introduced
+    output_dir.mkdir(exist_ok=True)
+    commits_file_path = output_dir / "commits.json"
+
+    commits = safely_load_json(commits_file_path)
+    if not commits or commits[-1] != stop_commit:
+        iterate_commits_and_extract_removed_code(linux_dir, stop_commit, commits_file_path, history_length)
+
+    last_processed = output_dir / LAST_PROCESSED_DIR
+    last_processed.mkdir(exist_ok=True)
+    results_dir = output_dir/RESULTS_DIR
+    results_dir.mkdir(exist_ok=True)
+    errors_dir = results_dir / ERRORS_FILE_DIR
+    errors_dir.mkdir(exist_ok=True)
+
+    commits = json.loads(commits_file_path.read_text())
+    # commits = ["e589f9b7078e1c0191613cd736f598e81d2390de"]
+
+    if len(commits) == 1 or NUMBER_OF_PROCESSES == 1:
+        get_removed_lines(linux_dir, commits, results_dir / "atoms.csv", last_processed / "last_processed.json", errors_dir / "errors.json")
+    else:
+        execute(linux_dir, commits, NUMBER_OF_PROCESSES, results_dir, last_processed, errors_dir)
+
+    combine_results(results_dir)
+
+if __name__ == "__main__":
+    extract_linux_fixes(Path("../projects/linux/"), Path("./output"), "one week")


### PR DESCRIPTION
- Fixed commit.hex to str(commit.id)
- Created aoc-extract-linux fixes tool
   -moved main function of extract_fixes.py to aoc-linux-fixes.py in tools
   -added aoc-linux-fixes to setup.py for install
   -added command line options for linux directory, output directory, multiprocessing, and history length
   -added ability to select length of time for commits to process instead of always going all the way back to the when "Fixes:" was introduced.
- modified multiprocessing for linux fixes to use a shared queue instead of static partitioning of commits

- added new tool to readme 
- added additional dependencies to setup.py